### PR TITLE
fix(flash-swap): liquidation dust issue

### DIFF
--- a/packages/flash-swap/contracts/uniswap-v2/HifiFlashUniswapV2.sol
+++ b/packages/flash-swap/contracts/uniswap-v2/HifiFlashUniswapV2.sol
@@ -214,8 +214,14 @@ contract HifiFlashUniswapV2 is IHifiFlashUniswapV2 {
         }
 
         // Liquidate borrow with the newly minted hTokens.
+        uint256 debtAmount = balanceSheet.getDebtAmount(borrower, bond);
         uint256 oldCollateralBalance = collateral.balanceOf(address(this));
-        balanceSheet.liquidateBorrow(borrower, bond, mintedHTokenAmount, collateral);
+        balanceSheet.liquidateBorrow(
+            borrower,
+            bond,
+            mintedHTokenAmount > debtAmount ? debtAmount : mintedHTokenAmount,
+            collateral
+        );
         uint256 newCollateralBalance = collateral.balanceOf(address(this));
         unchecked {
             seizedCollateralAmount = newCollateralBalance - oldCollateralBalance;


### PR DESCRIPTION
This fix allows to liquidate an entire bond position without leaving any bond dust.
Addresses: https://github.com/hifi-finance/hifi/issues/55