### PR TITLE
feat(flash-swap): support liquidating vaults with underlying as collateral

### DIFF
--- a/packages/constants/src/flashSwap.ts
+++ b/packages/constants/src/flashSwap.ts
@@ -1,4 +1,4 @@
-export enum REPAY_TYPE {
+export enum RepayType {
   SINGLE_TOKEN = "0",
   MULTI_TOKEN = "1",
 }

--- a/packages/constants/src/flashSwap.ts
+++ b/packages/constants/src/flashSwap.ts
@@ -1,0 +1,4 @@
+export enum REPAY_TYPE {
+  SINGLE_TOKEN = "0",
+  MULTI_TOKEN = "1",
+}

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./addresses";
 export * from "./chains";
+export * from "./flashSwap";
 export * from "./gas";
 export * from "./prices";
 export * from "./protocol";

--- a/packages/flash-swap/src/types/HifiFlashUniswapV2.d.ts
+++ b/packages/flash-swap/src/types/HifiFlashUniswapV2.d.ts
@@ -22,8 +22,8 @@ import type { TypedEventFilter, TypedEvent, TypedListener } from "./common";
 interface HifiFlashUniswapV2Interface extends ethers.utils.Interface {
   functions: {
     "balanceSheet()": FunctionFragment;
-    "getCollateralAndUnderlyingAmount(address,uint256,uint256,address)": FunctionFragment;
-    "getRepayCollateralAmount(address,address,uint256)": FunctionFragment;
+    "getCollateralAndUnderlyingAmount(address,uint8,uint256,uint256,address)": FunctionFragment;
+    "getRepayCollateralAmount(address,uint8,address,uint256)": FunctionFragment;
     "uniV2Factory()": FunctionFragment;
     "uniV2PairInitCodeHash()": FunctionFragment;
     "uniswapV2Call(address,uint256,uint256,bytes)": FunctionFragment;
@@ -35,11 +35,11 @@ interface HifiFlashUniswapV2Interface extends ethers.utils.Interface {
   ): string;
   encodeFunctionData(
     functionFragment: "getCollateralAndUnderlyingAmount",
-    values: [string, BigNumberish, BigNumberish, string]
+    values: [string, BigNumberish, BigNumberish, BigNumberish, string]
   ): string;
   encodeFunctionData(
     functionFragment: "getRepayCollateralAmount",
-    values: [string, string, BigNumberish]
+    values: [string, BigNumberish, string, BigNumberish]
   ): string;
   encodeFunctionData(
     functionFragment: "uniV2Factory",
@@ -145,6 +145,7 @@ export class HifiFlashUniswapV2 extends BaseContract {
 
     getCollateralAndUnderlyingAmount(
       pair: string,
+      repayType: BigNumberish,
       amount0: BigNumberish,
       amount1: BigNumberish,
       underlying: string,
@@ -155,6 +156,7 @@ export class HifiFlashUniswapV2 extends BaseContract {
 
     getRepayCollateralAmount(
       pair: string,
+      repayType: BigNumberish,
       underlying: string,
       underlyingAmount: BigNumberish,
       overrides?: CallOverrides
@@ -177,6 +179,7 @@ export class HifiFlashUniswapV2 extends BaseContract {
 
   getCollateralAndUnderlyingAmount(
     pair: string,
+    repayType: BigNumberish,
     amount0: BigNumberish,
     amount1: BigNumberish,
     underlying: string,
@@ -187,6 +190,7 @@ export class HifiFlashUniswapV2 extends BaseContract {
 
   getRepayCollateralAmount(
     pair: string,
+    repayType: BigNumberish,
     underlying: string,
     underlyingAmount: BigNumberish,
     overrides?: CallOverrides
@@ -209,6 +213,7 @@ export class HifiFlashUniswapV2 extends BaseContract {
 
     getCollateralAndUnderlyingAmount(
       pair: string,
+      repayType: BigNumberish,
       amount0: BigNumberish,
       amount1: BigNumberish,
       underlying: string,
@@ -219,6 +224,7 @@ export class HifiFlashUniswapV2 extends BaseContract {
 
     getRepayCollateralAmount(
       pair: string,
+      repayType: BigNumberish,
       underlying: string,
       underlyingAmount: BigNumberish,
       overrides?: CallOverrides
@@ -282,6 +288,7 @@ export class HifiFlashUniswapV2 extends BaseContract {
 
     getCollateralAndUnderlyingAmount(
       pair: string,
+      repayType: BigNumberish,
       amount0: BigNumberish,
       amount1: BigNumberish,
       underlying: string,
@@ -290,6 +297,7 @@ export class HifiFlashUniswapV2 extends BaseContract {
 
     getRepayCollateralAmount(
       pair: string,
+      repayType: BigNumberish,
       underlying: string,
       underlyingAmount: BigNumberish,
       overrides?: CallOverrides
@@ -313,6 +321,7 @@ export class HifiFlashUniswapV2 extends BaseContract {
 
     getCollateralAndUnderlyingAmount(
       pair: string,
+      repayType: BigNumberish,
       amount0: BigNumberish,
       amount1: BigNumberish,
       underlying: string,
@@ -321,6 +330,7 @@ export class HifiFlashUniswapV2 extends BaseContract {
 
     getRepayCollateralAmount(
       pair: string,
+      repayType: BigNumberish,
       underlying: string,
       underlyingAmount: BigNumberish,
       overrides?: CallOverrides

--- a/packages/flash-swap/src/types/IHifiFlashUniswapV2.d.ts
+++ b/packages/flash-swap/src/types/IHifiFlashUniswapV2.d.ts
@@ -22,8 +22,8 @@ import type { TypedEventFilter, TypedEvent, TypedListener } from "./common";
 interface IHifiFlashUniswapV2Interface extends ethers.utils.Interface {
   functions: {
     "balanceSheet()": FunctionFragment;
-    "getCollateralAndUnderlyingAmount(address,uint256,uint256,address)": FunctionFragment;
-    "getRepayCollateralAmount(address,address,uint256)": FunctionFragment;
+    "getCollateralAndUnderlyingAmount(address,uint8,uint256,uint256,address)": FunctionFragment;
+    "getRepayCollateralAmount(address,uint8,address,uint256)": FunctionFragment;
     "uniV2Factory()": FunctionFragment;
     "uniV2PairInitCodeHash()": FunctionFragment;
     "uniswapV2Call(address,uint256,uint256,bytes)": FunctionFragment;
@@ -35,11 +35,11 @@ interface IHifiFlashUniswapV2Interface extends ethers.utils.Interface {
   ): string;
   encodeFunctionData(
     functionFragment: "getCollateralAndUnderlyingAmount",
-    values: [string, BigNumberish, BigNumberish, string]
+    values: [string, BigNumberish, BigNumberish, BigNumberish, string]
   ): string;
   encodeFunctionData(
     functionFragment: "getRepayCollateralAmount",
-    values: [string, string, BigNumberish]
+    values: [string, BigNumberish, string, BigNumberish]
   ): string;
   encodeFunctionData(
     functionFragment: "uniV2Factory",
@@ -145,6 +145,7 @@ export class IHifiFlashUniswapV2 extends BaseContract {
 
     getCollateralAndUnderlyingAmount(
       pair: string,
+      repayType: BigNumberish,
       amount0: BigNumberish,
       amount1: BigNumberish,
       underlying: string,
@@ -155,6 +156,7 @@ export class IHifiFlashUniswapV2 extends BaseContract {
 
     getRepayCollateralAmount(
       pair: string,
+      repayType: BigNumberish,
       underlying: string,
       underlyingAmount: BigNumberish,
       overrides?: CallOverrides
@@ -177,6 +179,7 @@ export class IHifiFlashUniswapV2 extends BaseContract {
 
   getCollateralAndUnderlyingAmount(
     pair: string,
+    repayType: BigNumberish,
     amount0: BigNumberish,
     amount1: BigNumberish,
     underlying: string,
@@ -187,6 +190,7 @@ export class IHifiFlashUniswapV2 extends BaseContract {
 
   getRepayCollateralAmount(
     pair: string,
+    repayType: BigNumberish,
     underlying: string,
     underlyingAmount: BigNumberish,
     overrides?: CallOverrides
@@ -209,6 +213,7 @@ export class IHifiFlashUniswapV2 extends BaseContract {
 
     getCollateralAndUnderlyingAmount(
       pair: string,
+      repayType: BigNumberish,
       amount0: BigNumberish,
       amount1: BigNumberish,
       underlying: string,
@@ -219,6 +224,7 @@ export class IHifiFlashUniswapV2 extends BaseContract {
 
     getRepayCollateralAmount(
       pair: string,
+      repayType: BigNumberish,
       underlying: string,
       underlyingAmount: BigNumberish,
       overrides?: CallOverrides
@@ -282,6 +288,7 @@ export class IHifiFlashUniswapV2 extends BaseContract {
 
     getCollateralAndUnderlyingAmount(
       pair: string,
+      repayType: BigNumberish,
       amount0: BigNumberish,
       amount1: BigNumberish,
       underlying: string,
@@ -290,6 +297,7 @@ export class IHifiFlashUniswapV2 extends BaseContract {
 
     getRepayCollateralAmount(
       pair: string,
+      repayType: BigNumberish,
       underlying: string,
       underlyingAmount: BigNumberish,
       overrides?: CallOverrides
@@ -313,6 +321,7 @@ export class IHifiFlashUniswapV2 extends BaseContract {
 
     getCollateralAndUnderlyingAmount(
       pair: string,
+      repayType: BigNumberish,
       amount0: BigNumberish,
       amount1: BigNumberish,
       underlying: string,
@@ -321,6 +330,7 @@ export class IHifiFlashUniswapV2 extends BaseContract {
 
     getRepayCollateralAmount(
       pair: string,
+      repayType: BigNumberish,
       underlying: string,
       underlyingAmount: BigNumberish,
       overrides?: CallOverrides

--- a/packages/flash-swap/test/integration/hifiFlashUniswapV2/effects/uniswapV2Call.ts
+++ b/packages/flash-swap/test/integration/hifiFlashUniswapV2/effects/uniswapV2Call.ts
@@ -1,7 +1,7 @@
 import { defaultAbiCoder } from "@ethersproject/abi";
 import { BigNumber } from "@ethersproject/bignumber";
 import { Zero } from "@ethersproject/constants";
-import { REPAY_TYPE } from "@hifi/constants";
+import { RepayType } from "@hifi/constants";
 import { BalanceSheetErrors, HifiFlashUniswapV2Errors } from "@hifi/errors";
 import { USDC, WBTC, hUSDC, price } from "@hifi/helpers";
 import { expect } from "chai";
@@ -25,49 +25,49 @@ async function bumpPoolReserves(this: Mocha.Context, wbtcAmount: BigNumber, usdc
   await this.contracts.uniswapV2Pair.sync();
 }
 
-function encodeCallData(this: Mocha.Context): string {
+function encodeCallData(this: Mocha.Context, minProfit: string, repayType: RepayType): string {
   const types = ["address", "address", "uint256", "uint8"];
-  const minProfit: string = String(WBTC("0.001"));
-  const values = [this.signers.borrower.address, this.contracts.hToken.address, minProfit, REPAY_TYPE.MULTI_TOKEN];
+  const values = [this.signers.borrower.address, this.contracts.hToken.address, minProfit, repayType];
   const data: string = defaultAbiCoder.encode(types, values);
   return data;
 }
 
 async function getSeizableAndProfitCollateralAmounts(
   this: Mocha.Context,
+  repayType: RepayType,
   repayHUsdcAmount: BigNumber,
   underlyingAmount: BigNumber,
-): Promise<{ expectedProfitWbtcAmount: BigNumber; seizableWbtcAmount: BigNumber }> {
-  const seizableWbtcAmount = await this.contracts.balanceSheet.getSeizableCollateralAmount(
+): Promise<{ expectedProfitCollateralAmount: BigNumber; seizableCollateralAmount: BigNumber }> {
+  const seizableCollateralAmount = await this.contracts.balanceSheet.getSeizableCollateralAmount(
     this.contracts.hToken.address,
     repayHUsdcAmount,
-    this.contracts.wbtc.address,
+    repayType == RepayType.SINGLE_TOKEN ? this.contracts.usdc.address : this.contracts.wbtc.address,
   );
-  const repayWbtcAmount = await this.contracts.hifiFlashUniswapV2.getRepayCollateralAmount(
+  const repayCollateralAmount = await this.contracts.hifiFlashUniswapV2.getRepayCollateralAmount(
     this.contracts.uniswapV2Pair.address,
-    REPAY_TYPE.MULTI_TOKEN,
+    repayType,
     this.contracts.usdc.address,
     underlyingAmount,
   );
-  const expectedProfitWbtcAmount = seizableWbtcAmount.sub(repayWbtcAmount);
-  return { expectedProfitWbtcAmount, seizableWbtcAmount };
+  const expectedProfitCollateralAmount = seizableCollateralAmount.sub(repayCollateralAmount);
+  return { expectedProfitCollateralAmount, seizableCollateralAmount };
 }
 
 async function getTokenAmounts(
   this: Mocha.Context,
-  wbtcAmount: BigNumber,
-  usdcAmount: BigNumber,
+  collateralAmount: BigNumber,
+  underlyingAmount: BigNumber,
 ): Promise<{ token0Amount: BigNumber; token1Amount: BigNumber }> {
   const token0: string = await this.contracts.uniswapV2Pair.token0();
   if (token0 == this.contracts.wbtc.address) {
     return {
-      token0Amount: wbtcAmount,
-      token1Amount: usdcAmount,
+      token0Amount: collateralAmount,
+      token1Amount: underlyingAmount,
     };
   } else {
     return {
-      token0Amount: usdcAmount,
-      token1Amount: wbtcAmount,
+      token0Amount: underlyingAmount,
+      token1Amount: collateralAmount,
     };
   }
 }
@@ -106,7 +106,7 @@ export function shouldBehaveLikeUniswapV2Call(): void {
     let data: string;
 
     beforeEach(function () {
-      data = encodeCallData.call(this);
+      data = encodeCallData.call(this, String(USDC("0")), RepayType.SINGLE_TOKEN);
     });
 
     context("when the caller is not the UniswapV2Pair contract", function () {
@@ -162,94 +162,120 @@ export function shouldBehaveLikeUniswapV2Call(): void {
         });
       });
 
-      context("when the underlying is in the pair contract", function () {
-        context("when collateral is flash borrowed", function () {
-          it("reverts", async function () {
-            const { token0Amount, token1Amount } = await getTokenAmounts.call(this, WBTC("1"), Zero);
-            const to: string = this.contracts.hifiFlashUniswapV2.address;
-            await expect(
-              this.contracts.uniswapV2Pair.connect(this.signers.raider).swap(token0Amount, token1Amount, to, data),
-            ).to.be.revertedWith(HifiFlashUniswapV2Errors.FlashBorrowCollateral);
-          });
-        });
-
-        context("when underlying is flash borrowed", function () {
-          const borrowAmount: BigNumber = hUSDC("10000");
-          const collateralAmount: BigNumber = Zero;
-          const collateralCeiling: BigNumber = WBTC("100");
-          const debtCeiling: BigNumber = hUSDC("1e6");
-          const liquidationIncentive: BigNumber = toBn("1.10");
-          const underlyingAmount: BigNumber = USDC("10000");
-          const wbtcDepositAmount: BigNumber = WBTC("1");
-
-          let token0Amount: BigNumber;
-          let token1Amount: BigNumber;
-
-          beforeEach(async function () {
-            const tokenAmounts = await getTokenAmounts.call(this, collateralAmount, underlyingAmount);
-            token0Amount = tokenAmounts.token0Amount;
-            token1Amount = tokenAmounts.token1Amount;
-
-            // List the bond in the Fintroller.
-            await this.contracts.fintroller.connect(this.signers.admin).listBond(this.contracts.hToken.address);
-
-            // List the collateral in the Fintroller.
-            await this.contracts.fintroller.connect(this.signers.admin).listCollateral(this.contracts.wbtc.address);
-
-            // Set the liquidation incentive.
-            await this.contracts.fintroller
-              .connect(this.signers.admin)
-              .setLiquidationIncentive(this.contracts.wbtc.address, liquidationIncentive);
-
-            // Set the collateral ceiling.
-            await this.contracts.fintroller
-              .connect(this.signers.admin)
-              .setCollateralCeiling(this.contracts.wbtc.address, collateralCeiling);
-
-            // Set the debt ceiling.
-            await this.contracts.fintroller
-              .connect(this.signers.admin)
-              .setDebtCeiling(this.contracts.hToken.address, debtCeiling);
-
-            // Mint WBTC and approve the BalanceSheet to spend it.
-            await this.contracts.wbtc.__godMode_mint(this.signers.borrower.address, wbtcDepositAmount);
-            await this.contracts.wbtc
-              .connect(this.signers.borrower)
-              .approve(this.contracts.balanceSheet.address, wbtcDepositAmount);
-
-            // Deposit the WBTC in the BalanceSheet.
-            await this.contracts.balanceSheet
-              .connect(this.signers.borrower)
-              .depositCollateral(this.contracts.wbtc.address, wbtcDepositAmount);
-
-            // Borrow hUSDC.
-            await this.contracts.balanceSheet
-              .connect(this.signers.borrower)
-              .borrow(this.contracts.hToken.address, borrowAmount);
-          });
-
-          context("when the borrower does not have a liquidity shortfall", function () {
+      context("when the repay type is single-token", function () {
+        context("when the underlying is in the pair contract", function () {
+          context("when collateral is flash borrowed", function () {
             it("reverts", async function () {
+              const { token0Amount, token1Amount } = await getTokenAmounts.call(this, WBTC("1"), Zero);
               const to: string = this.contracts.hifiFlashUniswapV2.address;
               await expect(
-                this.contracts.uniswapV2Pair
-                  .connect(this.signers.liquidator)
-                  .swap(token0Amount, token1Amount, to, data),
-              ).to.be.revertedWith(BalanceSheetErrors.NO_LIQUIDITY_SHORTFALL);
+                this.contracts.uniswapV2Pair.connect(this.signers.raider).swap(token0Amount, token1Amount, to, data),
+              ).to.be.revertedWith(HifiFlashUniswapV2Errors.FlashBorrowCollateral);
             });
           });
 
-          context("when the borrower has a liquidity shortfall", function () {
+          context("when underlying is flash borrowed", function () {
+            const borrowAmount: BigNumber = hUSDC("10000");
+            const collateralAmount: BigNumber = Zero;
+            const usdcCollateralCeiling: BigNumber = USDC("1000000");
+            const wbtcCollateralCeiling: BigNumber = WBTC("50");
+            const debtCeiling: BigNumber = hUSDC("1e6");
+            const usdcLiquidationIncentive: BigNumber = toBn("1");
+            const wbtcLiquidationIncentive: BigNumber = toBn("1.10");
+            const underlyingAmount: BigNumber = USDC("10000");
+            const usdcDepositAmount: BigNumber = USDC("10000");
+            const usdcRepayFeeAmount: BigNumber = USDC("30.090271");
+            const wbtcDepositAmount: BigNumber = WBTC("0.5");
+
+            let token0Amount: BigNumber;
+            let token1Amount: BigNumber;
+
+            beforeEach(async function () {
+              const tokenAmounts = await getTokenAmounts.call(this, collateralAmount, underlyingAmount);
+              token0Amount = tokenAmounts.token0Amount;
+              token1Amount = tokenAmounts.token1Amount;
+
+              // List the bond in the Fintroller.
+              await this.contracts.fintroller.connect(this.signers.admin).listBond(this.contracts.hToken.address);
+
+              // List the collaterals in the Fintroller.
+              await this.contracts.fintroller.connect(this.signers.admin).listCollateral(this.contracts.usdc.address);
+              await this.contracts.fintroller.connect(this.signers.admin).listCollateral(this.contracts.wbtc.address);
+
+              // Set the liquidation incentives.
+              await this.contracts.fintroller
+                .connect(this.signers.admin)
+                .setLiquidationIncentive(this.contracts.usdc.address, usdcLiquidationIncentive);
+              await this.contracts.fintroller
+                .connect(this.signers.admin)
+                .setLiquidationIncentive(this.contracts.wbtc.address, wbtcLiquidationIncentive);
+
+              // Set the collateral ceilings.
+              await this.contracts.fintroller
+                .connect(this.signers.admin)
+                .setCollateralCeiling(this.contracts.usdc.address, usdcCollateralCeiling);
+              await this.contracts.fintroller
+                .connect(this.signers.admin)
+                .setCollateralCeiling(this.contracts.wbtc.address, wbtcCollateralCeiling);
+
+              // Set the debt ceiling.
+              await this.contracts.fintroller
+                .connect(this.signers.admin)
+                .setDebtCeiling(this.contracts.hToken.address, debtCeiling);
+
+              // Mint USDC and approve the BalanceSheet to spend it.
+              await this.contracts.usdc.__godMode_mint(this.signers.borrower.address, usdcDepositAmount);
+              await this.contracts.usdc
+                .connect(this.signers.borrower)
+                .approve(this.contracts.balanceSheet.address, usdcDepositAmount);
+
+              // Mint WBTC and approve the BalanceSheet to spend it.
+              await this.contracts.wbtc.__godMode_mint(this.signers.borrower.address, wbtcDepositAmount);
+              await this.contracts.wbtc
+                .connect(this.signers.borrower)
+                .approve(this.contracts.balanceSheet.address, wbtcDepositAmount);
+
+              // Minst USDC and send it to flash-swap to be used for Uniswap V2 fee repay
+              await this.contracts.usdc.__godMode_mint(this.contracts.hifiFlashUniswapV2.address, usdcRepayFeeAmount);
+
+              // Deposit the USDC in the BalanceSheet.
+              await this.contracts.balanceSheet
+                .connect(this.signers.borrower)
+                .depositCollateral(this.contracts.usdc.address, usdcDepositAmount);
+
+              // Deposit the WBTC in the BalanceSheet.
+              await this.contracts.balanceSheet
+                .connect(this.signers.borrower)
+                .depositCollateral(this.contracts.wbtc.address, wbtcDepositAmount);
+
+              // Borrow hUSDC.
+              await this.contracts.balanceSheet
+                .connect(this.signers.borrower)
+                .borrow(this.contracts.hToken.address, borrowAmount);
+            });
+
+            context("when the borrower does not have a liquidity shortfall", function () {
+              it("reverts", async function () {
+                const to: string = this.contracts.hifiFlashUniswapV2.address;
+                await expect(
+                  this.contracts.uniswapV2Pair
+                    .connect(this.signers.liquidator)
+                    .swap(token0Amount, token1Amount, to, data),
+                ).to.be.revertedWith(BalanceSheetErrors.NO_LIQUIDITY_SHORTFALL);
+              });
+            });
+
             context("when the price given by the pair contract price is better than the oracle price", function () {
               beforeEach(async function () {
-                // Set the WBTC price to $12.5k to make borrower's collateral ratio 125%.
-                await this.contracts.wbtcPriceFeed.setPrice(price("12500"));
+                // Set the WBTC price to $5k to make borrower's collateral ratio 125%.
+                await this.contracts.wbtcPriceFeed.setPrice(price("5000"));
 
-                // Burn 1m USDC from the pair contract. This makes the pair contract price 1 WBTC ~ 10k USDC.
-                await reducePoolReserves.call(this, Zero, USDC("1e6"));
+                // Burn 1.75m USDC from the pair contract. This makes the pair contract price 1 WBTC ~ 2.5k USDC.
+                await reducePoolReserves.call(this, Zero, USDC("1.75e6"));
               });
 
               it("reverts", async function () {
+                data = encodeCallData.call(this, String(1), RepayType.SINGLE_TOKEN);
                 const to: string = this.contracts.hifiFlashUniswapV2.address;
                 await expect(
                   this.contracts.uniswapV2Pair
@@ -259,115 +285,355 @@ export function shouldBehaveLikeUniswapV2Call(): void {
               });
             });
 
-            context("when the price given by the pair contract is the same as the oracle price", function () {
-              let expectedProfitWbtcAmount: BigNumber;
-              let seizableWbtcAmount: BigNumber;
+            context("when the borrower has a liquidity shortfall", function () {
+              context("when the price given by the pair contract is the same as the oracle price", function () {
+                let seizableUsdcAmount: BigNumber;
 
-              context("when the collateral ratio is lower than 110%", function () {
-                const repayHUsdcAmount: BigNumber = hUSDC("9090.909090909090909090");
+                context("when the collateral ratio is lower than 110%", function () {
+                  const repayHUsdcAmount: BigNumber = hUSDC("9090.909090909090909090");
 
-                beforeEach(async function () {
-                  // Set the WBTC price to $10k to make the borrower's collateral ratio 100%.
-                  await this.contracts.wbtcPriceFeed.setPrice(price("10000"));
+                  beforeEach(async function () {
+                    // Set the WBTC price to $10k to make the borrower's collateral ratio 100%.
+                    await this.contracts.wbtcPriceFeed.setPrice(price("10000"));
 
-                  // Calculate the amounts necessary for running the tests.
-                  const calculatesAmounts = await getSeizableAndProfitCollateralAmounts.call(
-                    this,
-                    repayHUsdcAmount,
-                    underlyingAmount,
-                  );
-                  expectedProfitWbtcAmount = calculatesAmounts.expectedProfitWbtcAmount;
-                  seizableWbtcAmount = calculatesAmounts.seizableWbtcAmount;
+                    // Calculate the amounts necessary for running the tests.
+                    const calculatesAmounts = await getSeizableAndProfitCollateralAmounts.call(
+                      this,
+                      RepayType.SINGLE_TOKEN,
+                      repayHUsdcAmount,
+                      underlyingAmount,
+                    );
+                    seizableUsdcAmount = calculatesAmounts.seizableCollateralAmount;
+                  });
+
+                  it("flash swaps USDC making no USDC profit and spending allocated USDC to pay swap fee", async function () {
+                    const to: string = this.contracts.hifiFlashUniswapV2.address;
+                    const preUsdcBalanceAccount = await this.contracts.usdc.balanceOf(this.signers.liquidator.address);
+                    const preUsdcBalanceContract = await this.contracts.usdc.balanceOf(to);
+                    await this.contracts.uniswapV2Pair
+                      .connect(this.signers.liquidator)
+                      .swap(token0Amount, token1Amount, to, data);
+                    const newUsdcBalanceAccount = await this.contracts.usdc.balanceOf(this.signers.liquidator.address);
+                    const newUsdcBalanceContract = await this.contracts.usdc.balanceOf(to);
+                    expect(newUsdcBalanceAccount).to.equal(preUsdcBalanceAccount);
+                    expect(preUsdcBalanceContract.sub(newUsdcBalanceContract)).to.equal(usdcRepayFeeAmount);
+                  });
                 });
 
-                it("flash swaps USDC via and makes a WBTC profit", async function () {
-                  const to: string = this.contracts.hifiFlashUniswapV2.address;
-                  const preWbtcBalance = await this.contracts.wbtc.balanceOf(this.signers.liquidator.address);
-                  await this.contracts.uniswapV2Pair
-                    .connect(this.signers.liquidator)
-                    .swap(token0Amount, token1Amount, to, data);
-                  const newWbtcBalance = await this.contracts.wbtc.balanceOf(this.signers.liquidator.address);
-                  expect(newWbtcBalance.sub(expectedProfitWbtcAmount)).to.equal(preWbtcBalance);
+                context("when the collateral ratio is lower than 150% but higher than 110%", function () {
+                  const repayHUsdcAmount: BigNumber = hUSDC("10000");
+
+                  beforeEach(async function () {
+                    // Set the WBTC price to $5k to make borrower's collateral ratio 125%.
+                    await this.contracts.wbtcPriceFeed.setPrice(price("5000"));
+
+                    // Burn 1.5m USDC from the pair contract, which makes the price 1 WBTC ~ 5k USDC.
+                    await reducePoolReserves.call(this, Zero, USDC("1.5e6"));
+
+                    // Calculate the amounts necessary for running the tests.
+                    const calculatesAmounts = await getSeizableAndProfitCollateralAmounts.call(
+                      this,
+                      RepayType.SINGLE_TOKEN,
+                      repayHUsdcAmount,
+                      underlyingAmount,
+                    );
+                    seizableUsdcAmount = calculatesAmounts.seizableCollateralAmount;
+                  });
+
+                  context("new order of tokens in the pair", function () {
+                    let localToken0Amount: BigNumber;
+                    let localToken1Amount: BigNumber;
+
+                    beforeEach(async function () {
+                      const token0: string = await this.contracts.uniswapV2Pair.token0();
+                      if (token0 == this.contracts.wbtc.address) {
+                        await this.contracts.uniswapV2Pair.__godMode_setToken0(this.contracts.usdc.address);
+                        await this.contracts.uniswapV2Pair.__godMode_setToken1(this.contracts.wbtc.address);
+                        localToken0Amount = underlyingAmount;
+                        localToken1Amount = collateralAmount;
+                      } else {
+                        await this.contracts.uniswapV2Pair.__godMode_setToken0(this.contracts.wbtc.address);
+                        await this.contracts.uniswapV2Pair.__godMode_setToken1(this.contracts.usdc.address);
+                        localToken0Amount = collateralAmount;
+                        localToken1Amount = underlyingAmount;
+                      }
+                      await this.contracts.uniswapV2Pair.sync();
+                    });
+
+                    it("flash swaps USDC making no USDC profit and spending allocated USDC to pay swap fee", async function () {
+                      const to: string = this.contracts.hifiFlashUniswapV2.address;
+                      const preUsdcBalanceAccount = await this.contracts.usdc.balanceOf(
+                        this.signers.liquidator.address,
+                      );
+                      const preUsdcBalanceContract = await this.contracts.usdc.balanceOf(to);
+                      await this.contracts.uniswapV2Pair
+                        .connect(this.signers.liquidator)
+                        .swap(localToken0Amount, localToken1Amount, to, data);
+                      const newUsdcBalanceAccount = await this.contracts.usdc.balanceOf(
+                        this.signers.liquidator.address,
+                      );
+                      const newUsdcBalanceContract = await this.contracts.usdc.balanceOf(to);
+                      expect(newUsdcBalanceAccount).to.equal(preUsdcBalanceAccount);
+                      expect(preUsdcBalanceContract.sub(newUsdcBalanceContract)).to.equal(usdcRepayFeeAmount);
+                    });
+                  });
+
+                  context("initial order of tokens in the pair", function () {
+                    it("flash swaps USDC making no USDC profit and spending allocated USDC to pay swap fee", async function () {
+                      const to: string = this.contracts.hifiFlashUniswapV2.address;
+                      const preUsdcBalanceAccount = await this.contracts.usdc.balanceOf(
+                        this.signers.liquidator.address,
+                      );
+                      const preUsdcBalanceContract = await this.contracts.usdc.balanceOf(to);
+                      await this.contracts.uniswapV2Pair
+                        .connect(this.signers.liquidator)
+                        .swap(token0Amount, token1Amount, to, data);
+                      const newUsdcBalanceAccount = await this.contracts.usdc.balanceOf(
+                        this.signers.liquidator.address,
+                      );
+                      const newUsdcBalanceContract = await this.contracts.usdc.balanceOf(to);
+                      expect(newUsdcBalanceAccount).to.equal(preUsdcBalanceAccount);
+                      expect(preUsdcBalanceContract.sub(newUsdcBalanceContract)).to.equal(usdcRepayFeeAmount);
+                    });
+
+                    it("emits a FlashLiquidateBorrow event", async function () {
+                      const to: string = this.contracts.hifiFlashUniswapV2.address;
+                      const contractCall = this.contracts.uniswapV2Pair
+                        .connect(this.signers.liquidator)
+                        .swap(token0Amount, token1Amount, to, data);
+                      await expect(contractCall)
+                        .to.emit(this.contracts.hifiFlashUniswapV2, "FlashLiquidateBorrow")
+                        .withArgs(
+                          this.signers.liquidator.address,
+                          this.signers.borrower.address,
+                          this.contracts.hToken.address,
+                          underlyingAmount,
+                          seizableUsdcAmount,
+                          USDC("0"),
+                        );
+                    });
+                  });
                 });
               });
+            });
+          });
+        });
+      });
 
-              context("when the collateral ratio is lower than 150% but higher than 110%", function () {
-                const repayHUsdcAmount: BigNumber = hUSDC("10000");
+      context("when the repay type is multi-token", function () {
+        beforeEach(function () {
+          data = encodeCallData.call(this, String(WBTC("0.001")), RepayType.MULTI_TOKEN);
+        });
 
+        context("when the underlying is in the pair contract", function () {
+          context("when collateral is flash borrowed", function () {
+            it("reverts", async function () {
+              const { token0Amount, token1Amount } = await getTokenAmounts.call(this, WBTC("1"), Zero);
+              const to: string = this.contracts.hifiFlashUniswapV2.address;
+              await expect(
+                this.contracts.uniswapV2Pair.connect(this.signers.raider).swap(token0Amount, token1Amount, to, data),
+              ).to.be.revertedWith(HifiFlashUniswapV2Errors.FlashBorrowCollateral);
+            });
+          });
+
+          context("when underlying is flash borrowed", function () {
+            const borrowAmount: BigNumber = hUSDC("10000");
+            const collateralAmount: BigNumber = Zero;
+            const collateralCeiling: BigNumber = WBTC("100");
+            const debtCeiling: BigNumber = hUSDC("1e6");
+            const liquidationIncentive: BigNumber = toBn("1.10");
+            const underlyingAmount: BigNumber = USDC("10000");
+            const wbtcDepositAmount: BigNumber = WBTC("1");
+
+            let token0Amount: BigNumber;
+            let token1Amount: BigNumber;
+
+            beforeEach(async function () {
+              const tokenAmounts = await getTokenAmounts.call(this, collateralAmount, underlyingAmount);
+              token0Amount = tokenAmounts.token0Amount;
+              token1Amount = tokenAmounts.token1Amount;
+
+              // List the bond in the Fintroller.
+              await this.contracts.fintroller.connect(this.signers.admin).listBond(this.contracts.hToken.address);
+
+              // List the collateral in the Fintroller.
+              await this.contracts.fintroller.connect(this.signers.admin).listCollateral(this.contracts.wbtc.address);
+
+              // Set the liquidation incentive.
+              await this.contracts.fintroller
+                .connect(this.signers.admin)
+                .setLiquidationIncentive(this.contracts.wbtc.address, liquidationIncentive);
+
+              // Set the collateral ceiling.
+              await this.contracts.fintroller
+                .connect(this.signers.admin)
+                .setCollateralCeiling(this.contracts.wbtc.address, collateralCeiling);
+
+              // Set the debt ceiling.
+              await this.contracts.fintroller
+                .connect(this.signers.admin)
+                .setDebtCeiling(this.contracts.hToken.address, debtCeiling);
+
+              // Mint WBTC and approve the BalanceSheet to spend it.
+              await this.contracts.wbtc.__godMode_mint(this.signers.borrower.address, wbtcDepositAmount);
+              await this.contracts.wbtc
+                .connect(this.signers.borrower)
+                .approve(this.contracts.balanceSheet.address, wbtcDepositAmount);
+
+              // Deposit the WBTC in the BalanceSheet.
+              await this.contracts.balanceSheet
+                .connect(this.signers.borrower)
+                .depositCollateral(this.contracts.wbtc.address, wbtcDepositAmount);
+
+              // Borrow hUSDC.
+              await this.contracts.balanceSheet
+                .connect(this.signers.borrower)
+                .borrow(this.contracts.hToken.address, borrowAmount);
+            });
+
+            context("when the borrower does not have a liquidity shortfall", function () {
+              it("reverts", async function () {
+                const to: string = this.contracts.hifiFlashUniswapV2.address;
+                await expect(
+                  this.contracts.uniswapV2Pair
+                    .connect(this.signers.liquidator)
+                    .swap(token0Amount, token1Amount, to, data),
+                ).to.be.revertedWith(BalanceSheetErrors.NO_LIQUIDITY_SHORTFALL);
+              });
+            });
+
+            context("when the borrower has a liquidity shortfall", function () {
+              context("when the price given by the pair contract price is better than the oracle price", function () {
                 beforeEach(async function () {
                   // Set the WBTC price to $12.5k to make borrower's collateral ratio 125%.
                   await this.contracts.wbtcPriceFeed.setPrice(price("12500"));
 
-                  // Burn 750k USDC from the pair contract, which makes the price 1 WBTC ~ 12.5k USDC.
-                  await reducePoolReserves.call(this, Zero, USDC("75e4"));
-
-                  // Calculate the amounts necessary for running the tests.
-                  const calculatesAmounts = await getSeizableAndProfitCollateralAmounts.call(
-                    this,
-                    repayHUsdcAmount,
-                    underlyingAmount,
-                  );
-                  expectedProfitWbtcAmount = calculatesAmounts.expectedProfitWbtcAmount;
-                  seizableWbtcAmount = calculatesAmounts.seizableWbtcAmount;
+                  // Burn 1m USDC from the pair contract. This makes the pair contract price 1 WBTC ~ 10k USDC.
+                  await reducePoolReserves.call(this, Zero, USDC("1e6"));
                 });
 
-                context("new order of tokens in the pair", function () {
-                  let localToken0Amount: BigNumber;
-                  let localToken1Amount: BigNumber;
+                it("reverts", async function () {
+                  const to: string = this.contracts.hifiFlashUniswapV2.address;
+                  await expect(
+                    this.contracts.uniswapV2Pair
+                      .connect(this.signers.liquidator)
+                      .swap(token0Amount, token1Amount, to, data),
+                  ).to.be.revertedWith(HifiFlashUniswapV2Errors.InsufficientProfit);
+                });
+              });
+
+              context("when the price given by the pair contract is the same as the oracle price", function () {
+                let expectedProfitWbtcAmount: BigNumber;
+                let seizableWbtcAmount: BigNumber;
+
+                context("when the collateral ratio is lower than 110%", function () {
+                  const repayHUsdcAmount: BigNumber = hUSDC("9090.909090909090909090");
 
                   beforeEach(async function () {
-                    const token0: string = await this.contracts.uniswapV2Pair.token0();
-                    if (token0 == this.contracts.wbtc.address) {
-                      await this.contracts.uniswapV2Pair.__godMode_setToken0(this.contracts.usdc.address);
-                      await this.contracts.uniswapV2Pair.__godMode_setToken1(this.contracts.wbtc.address);
-                      localToken0Amount = underlyingAmount;
-                      localToken1Amount = collateralAmount;
-                    } else {
-                      await this.contracts.uniswapV2Pair.__godMode_setToken0(this.contracts.wbtc.address);
-                      await this.contracts.uniswapV2Pair.__godMode_setToken1(this.contracts.usdc.address);
-                      localToken0Amount = collateralAmount;
-                      localToken1Amount = underlyingAmount;
-                    }
-                    await this.contracts.uniswapV2Pair.sync();
+                    // Set the WBTC price to $10k to make the borrower's collateral ratio 100%.
+                    await this.contracts.wbtcPriceFeed.setPrice(price("10000"));
+
+                    // Calculate the amounts necessary for running the tests.
+                    const calculatesAmounts = await getSeizableAndProfitCollateralAmounts.call(
+                      this,
+                      RepayType.MULTI_TOKEN,
+                      repayHUsdcAmount,
+                      underlyingAmount,
+                    );
+                    expectedProfitWbtcAmount = calculatesAmounts.expectedProfitCollateralAmount;
+                    seizableWbtcAmount = calculatesAmounts.seizableCollateralAmount;
                   });
 
-                  it("flash swaps USDC via and makes a WBTC profit", async function () {
+                  it("flash swaps USDC and makes a WBTC profit", async function () {
                     const to: string = this.contracts.hifiFlashUniswapV2.address;
                     const preWbtcBalance = await this.contracts.wbtc.balanceOf(this.signers.liquidator.address);
                     await this.contracts.uniswapV2Pair
                       .connect(this.signers.liquidator)
-                      .swap(localToken0Amount, localToken1Amount, to, data);
+                      .swap(token0Amount, token1Amount, to, data);
                     const newWbtcBalance = await this.contracts.wbtc.balanceOf(this.signers.liquidator.address);
                     expect(newWbtcBalance.sub(expectedProfitWbtcAmount)).to.equal(preWbtcBalance);
                   });
                 });
 
-                context("initial order of tokens in the pair", function () {
-                  it("flash swaps USDC via and makes a WBTC profit", async function () {
-                    const to: string = this.contracts.hifiFlashUniswapV2.address;
-                    const preWbtcBalance = await this.contracts.wbtc.balanceOf(this.signers.liquidator.address);
-                    await this.contracts.uniswapV2Pair
-                      .connect(this.signers.liquidator)
-                      .swap(token0Amount, token1Amount, to, data);
-                    const newWbtcBalance = await this.contracts.wbtc.balanceOf(this.signers.liquidator.address);
-                    expect(newWbtcBalance.sub(expectedProfitWbtcAmount)).to.equal(preWbtcBalance);
+                context("when the collateral ratio is lower than 150% but higher than 110%", function () {
+                  const repayHUsdcAmount: BigNumber = hUSDC("10000");
+
+                  beforeEach(async function () {
+                    // Set the WBTC price to $12.5k to make borrower's collateral ratio 125%.
+                    await this.contracts.wbtcPriceFeed.setPrice(price("12500"));
+
+                    // Burn 750k USDC from the pair contract, which makes the price 1 WBTC ~ 12.5k USDC.
+                    await reducePoolReserves.call(this, Zero, USDC("75e4"));
+
+                    // Calculate the amounts necessary for running the tests.
+                    const calculatesAmounts = await getSeizableAndProfitCollateralAmounts.call(
+                      this,
+                      RepayType.MULTI_TOKEN,
+                      repayHUsdcAmount,
+                      underlyingAmount,
+                    );
+                    expectedProfitWbtcAmount = calculatesAmounts.expectedProfitCollateralAmount;
+                    seizableWbtcAmount = calculatesAmounts.seizableCollateralAmount;
                   });
 
-                  it("emits a FlashLiquidateBorrow event", async function () {
-                    const to: string = this.contracts.hifiFlashUniswapV2.address;
-                    const contractCall = this.contracts.uniswapV2Pair
-                      .connect(this.signers.liquidator)
-                      .swap(token0Amount, token1Amount, to, data);
-                    await expect(contractCall)
-                      .to.emit(this.contracts.hifiFlashUniswapV2, "FlashLiquidateBorrow")
-                      .withArgs(
-                        this.signers.liquidator.address,
-                        this.signers.borrower.address,
-                        this.contracts.hToken.address,
-                        underlyingAmount,
-                        seizableWbtcAmount,
-                        expectedProfitWbtcAmount,
-                      );
+                  context("new order of tokens in the pair", function () {
+                    let localToken0Amount: BigNumber;
+                    let localToken1Amount: BigNumber;
+
+                    beforeEach(async function () {
+                      const token0: string = await this.contracts.uniswapV2Pair.token0();
+                      if (token0 == this.contracts.wbtc.address) {
+                        await this.contracts.uniswapV2Pair.__godMode_setToken0(this.contracts.usdc.address);
+                        await this.contracts.uniswapV2Pair.__godMode_setToken1(this.contracts.wbtc.address);
+                        localToken0Amount = underlyingAmount;
+                        localToken1Amount = collateralAmount;
+                      } else {
+                        await this.contracts.uniswapV2Pair.__godMode_setToken0(this.contracts.wbtc.address);
+                        await this.contracts.uniswapV2Pair.__godMode_setToken1(this.contracts.usdc.address);
+                        localToken0Amount = collateralAmount;
+                        localToken1Amount = underlyingAmount;
+                      }
+                      await this.contracts.uniswapV2Pair.sync();
+                    });
+
+                    it("flash swaps USDC and makes a WBTC profit", async function () {
+                      const to: string = this.contracts.hifiFlashUniswapV2.address;
+                      const preWbtcBalance = await this.contracts.wbtc.balanceOf(this.signers.liquidator.address);
+                      await this.contracts.uniswapV2Pair
+                        .connect(this.signers.liquidator)
+                        .swap(localToken0Amount, localToken1Amount, to, data);
+                      const newWbtcBalance = await this.contracts.wbtc.balanceOf(this.signers.liquidator.address);
+                      expect(newWbtcBalance.sub(expectedProfitWbtcAmount)).to.equal(preWbtcBalance);
+                    });
+                  });
+
+                  context("initial order of tokens in the pair", function () {
+                    it("flash swaps USDC and makes a WBTC profit", async function () {
+                      const to: string = this.contracts.hifiFlashUniswapV2.address;
+                      const preWbtcBalance = await this.contracts.wbtc.balanceOf(this.signers.liquidator.address);
+                      await this.contracts.uniswapV2Pair
+                        .connect(this.signers.liquidator)
+                        .swap(token0Amount, token1Amount, to, data);
+                      const newWbtcBalance = await this.contracts.wbtc.balanceOf(this.signers.liquidator.address);
+                      expect(newWbtcBalance.sub(expectedProfitWbtcAmount)).to.equal(preWbtcBalance);
+                    });
+
+                    it("emits a FlashLiquidateBorrow event", async function () {
+                      const to: string = this.contracts.hifiFlashUniswapV2.address;
+                      const contractCall = this.contracts.uniswapV2Pair
+                        .connect(this.signers.liquidator)
+                        .swap(token0Amount, token1Amount, to, data);
+                      await expect(contractCall)
+                        .to.emit(this.contracts.hifiFlashUniswapV2, "FlashLiquidateBorrow")
+                        .withArgs(
+                          this.signers.liquidator.address,
+                          this.signers.borrower.address,
+                          this.contracts.hToken.address,
+                          underlyingAmount,
+                          seizableWbtcAmount,
+                          expectedProfitWbtcAmount,
+                        );
+                    });
                   });
                 });
               });

--- a/packages/flash-swap/test/integration/hifiFlashUniswapV2/effects/uniswapV2Call.ts
+++ b/packages/flash-swap/test/integration/hifiFlashUniswapV2/effects/uniswapV2Call.ts
@@ -1,6 +1,7 @@
 import { defaultAbiCoder } from "@ethersproject/abi";
 import { BigNumber } from "@ethersproject/bignumber";
 import { Zero } from "@ethersproject/constants";
+import { REPAY_TYPE } from "@hifi/constants";
 import { BalanceSheetErrors, HifiFlashUniswapV2Errors } from "@hifi/errors";
 import { USDC, WBTC, hUSDC, price } from "@hifi/helpers";
 import { expect } from "chai";
@@ -25,9 +26,9 @@ async function bumpPoolReserves(this: Mocha.Context, wbtcAmount: BigNumber, usdc
 }
 
 function encodeCallData(this: Mocha.Context): string {
-  const types = ["address", "address", "uint256"];
+  const types = ["address", "address", "uint256", "uint8"];
   const minProfit: string = String(WBTC("0.001"));
-  const values = [this.signers.borrower.address, this.contracts.hToken.address, minProfit];
+  const values = [this.signers.borrower.address, this.contracts.hToken.address, minProfit, REPAY_TYPE.MULTI_TOKEN];
   const data: string = defaultAbiCoder.encode(types, values);
   return data;
 }
@@ -44,6 +45,7 @@ async function getSeizableAndProfitCollateralAmounts(
   );
   const repayWbtcAmount = await this.contracts.hifiFlashUniswapV2.getRepayCollateralAmount(
     this.contracts.uniswapV2Pair.address,
+    REPAY_TYPE.MULTI_TOKEN,
     this.contracts.usdc.address,
     underlyingAmount,
   );

--- a/packages/protocol/src/types/HToken.d.ts
+++ b/packages/protocol/src/types/HToken.d.ts
@@ -481,7 +481,7 @@ export class HToken extends BaseContract {
     ): Promise<ContractTransaction>;
 
     supplyUnderlying(
-      underlyingSupplyAmount: BigNumberish,
+      underlyingAmount: BigNumberish,
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<ContractTransaction>;
 
@@ -614,7 +614,7 @@ export class HToken extends BaseContract {
   ): Promise<ContractTransaction>;
 
   supplyUnderlying(
-    underlyingSupplyAmount: BigNumberish,
+    underlyingAmount: BigNumberish,
     overrides?: Overrides & { from?: string | Promise<string> }
   ): Promise<ContractTransaction>;
 
@@ -745,7 +745,7 @@ export class HToken extends BaseContract {
     ): Promise<void>;
 
     supplyUnderlying(
-      underlyingSupplyAmount: BigNumberish,
+      underlyingAmount: BigNumberish,
       overrides?: CallOverrides
     ): Promise<void>;
 
@@ -1053,7 +1053,7 @@ export class HToken extends BaseContract {
     ): Promise<BigNumber>;
 
     supplyUnderlying(
-      underlyingSupplyAmount: BigNumberish,
+      underlyingAmount: BigNumberish,
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<BigNumber>;
 
@@ -1193,7 +1193,7 @@ export class HToken extends BaseContract {
     ): Promise<PopulatedTransaction>;
 
     supplyUnderlying(
-      underlyingSupplyAmount: BigNumberish,
+      underlyingAmount: BigNumberish,
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<PopulatedTransaction>;
 


### PR DESCRIPTION
Regarding liquidating USDC collateral, the following modifications needed to be applied to the flash-swap contract:

1. The bot is not able to access a USDC-USDC trading pair, and so for this special case we are assuming the use of any pair that has USDC on one side. In real life, the pair would preferably be the one with the largest liquidity out of all pairs containing USDC on one side.
2. Since we're only going to be using one side of the trading pair, we need to repay the borrowed USDC in USDC + 0.3% Uniswap v2 fee. This required modifying the `getRepayCollateralAmount(...)` function in flash-swap to enable different calculation for this special case.
3. We also needed to do something about the `msg.sender` verification in flash-swap, as it previously required the msg sender address to be equal to the pair address of underlying and collateral computed using `pairFor(...)`. Since it's not possible to have a USDC-USDC pair, we needed to constrain this check to the case where the underlying token is not the same as the collateral to be liquidated.
4. In most cases, the liquidated collateral is not going to be enough to repay the 0.3% Uniswap fee. A modification was needed to enable the flash-swap contract to repay the fee from its own balance if necessary.