### PR TITLE
feat(flash-swap): enable collateral subsidization

### DIFF
--- a/packages/flash-swap/contracts/uniswap-v2/ICollateralFlashUniswapV2.sol
+++ b/packages/flash-swap/contracts/uniswap-v2/ICollateralFlashUniswapV2.sol
@@ -19,6 +19,8 @@ interface ICollateralFlashUniswapV2 is IUniswapV2Callee {
         address indexed bond,
         uint256 underlyingAmount,
         uint256 seizedCollateralAmount,
+        uint256 repayCollateralAmount,
+        uint256 subsidizedCollateralAmount,
         uint256 profitCollateralAmount
     );
 

--- a/packages/flash-swap/src/types/CollateralFlashUniswapV2.d.ts
+++ b/packages/flash-swap/src/types/CollateralFlashUniswapV2.d.ts
@@ -80,7 +80,7 @@ interface CollateralFlashUniswapV2Interface extends ethers.utils.Interface {
   ): Result;
 
   events: {
-    "FlashSwapCollateralAndLiquidateBorrow(address,address,address,uint256,uint256,uint256)": EventFragment;
+    "FlashSwapCollateralAndLiquidateBorrow(address,address,address,uint256,uint256,uint256,uint256,uint256)": EventFragment;
   };
 
   getEvent(
@@ -89,12 +89,23 @@ interface CollateralFlashUniswapV2Interface extends ethers.utils.Interface {
 }
 
 export type FlashSwapCollateralAndLiquidateBorrowEvent = TypedEvent<
-  [string, string, string, BigNumber, BigNumber, BigNumber] & {
+  [
+    string,
+    string,
+    string,
+    BigNumber,
+    BigNumber,
+    BigNumber,
+    BigNumber,
+    BigNumber
+  ] & {
     liquidator: string;
     borrower: string;
     bond: string;
     underlyingAmount: BigNumber;
     seizedCollateralAmount: BigNumber;
+    repayCollateralAmount: BigNumber;
+    subsidizedCollateralAmount: BigNumber;
     profitCollateralAmount: BigNumber;
   }
 >;
@@ -240,21 +251,34 @@ export class CollateralFlashUniswapV2 extends BaseContract {
   };
 
   filters: {
-    "FlashSwapCollateralAndLiquidateBorrow(address,address,address,uint256,uint256,uint256)"(
+    "FlashSwapCollateralAndLiquidateBorrow(address,address,address,uint256,uint256,uint256,uint256,uint256)"(
       liquidator?: string | null,
       borrower?: string | null,
       bond?: string | null,
       underlyingAmount?: null,
       seizedCollateralAmount?: null,
+      repayCollateralAmount?: null,
+      subsidizedCollateralAmount?: null,
       profitCollateralAmount?: null
     ): TypedEventFilter<
-      [string, string, string, BigNumber, BigNumber, BigNumber],
+      [
+        string,
+        string,
+        string,
+        BigNumber,
+        BigNumber,
+        BigNumber,
+        BigNumber,
+        BigNumber
+      ],
       {
         liquidator: string;
         borrower: string;
         bond: string;
         underlyingAmount: BigNumber;
         seizedCollateralAmount: BigNumber;
+        repayCollateralAmount: BigNumber;
+        subsidizedCollateralAmount: BigNumber;
         profitCollateralAmount: BigNumber;
       }
     >;
@@ -265,15 +289,28 @@ export class CollateralFlashUniswapV2 extends BaseContract {
       bond?: string | null,
       underlyingAmount?: null,
       seizedCollateralAmount?: null,
+      repayCollateralAmount?: null,
+      subsidizedCollateralAmount?: null,
       profitCollateralAmount?: null
     ): TypedEventFilter<
-      [string, string, string, BigNumber, BigNumber, BigNumber],
+      [
+        string,
+        string,
+        string,
+        BigNumber,
+        BigNumber,
+        BigNumber,
+        BigNumber,
+        BigNumber
+      ],
       {
         liquidator: string;
         borrower: string;
         bond: string;
         underlyingAmount: BigNumber;
         seizedCollateralAmount: BigNumber;
+        repayCollateralAmount: BigNumber;
+        subsidizedCollateralAmount: BigNumber;
         profitCollateralAmount: BigNumber;
       }
     >;

--- a/packages/flash-swap/src/types/ICollateralFlashUniswapV2.d.ts
+++ b/packages/flash-swap/src/types/ICollateralFlashUniswapV2.d.ts
@@ -80,7 +80,7 @@ interface ICollateralFlashUniswapV2Interface extends ethers.utils.Interface {
   ): Result;
 
   events: {
-    "FlashSwapCollateralAndLiquidateBorrow(address,address,address,uint256,uint256,uint256)": EventFragment;
+    "FlashSwapCollateralAndLiquidateBorrow(address,address,address,uint256,uint256,uint256,uint256,uint256)": EventFragment;
   };
 
   getEvent(
@@ -89,12 +89,23 @@ interface ICollateralFlashUniswapV2Interface extends ethers.utils.Interface {
 }
 
 export type FlashSwapCollateralAndLiquidateBorrowEvent = TypedEvent<
-  [string, string, string, BigNumber, BigNumber, BigNumber] & {
+  [
+    string,
+    string,
+    string,
+    BigNumber,
+    BigNumber,
+    BigNumber,
+    BigNumber,
+    BigNumber
+  ] & {
     liquidator: string;
     borrower: string;
     bond: string;
     underlyingAmount: BigNumber;
     seizedCollateralAmount: BigNumber;
+    repayCollateralAmount: BigNumber;
+    subsidizedCollateralAmount: BigNumber;
     profitCollateralAmount: BigNumber;
   }
 >;
@@ -240,21 +251,34 @@ export class ICollateralFlashUniswapV2 extends BaseContract {
   };
 
   filters: {
-    "FlashSwapCollateralAndLiquidateBorrow(address,address,address,uint256,uint256,uint256)"(
+    "FlashSwapCollateralAndLiquidateBorrow(address,address,address,uint256,uint256,uint256,uint256,uint256)"(
       liquidator?: string | null,
       borrower?: string | null,
       bond?: string | null,
       underlyingAmount?: null,
       seizedCollateralAmount?: null,
+      repayCollateralAmount?: null,
+      subsidizedCollateralAmount?: null,
       profitCollateralAmount?: null
     ): TypedEventFilter<
-      [string, string, string, BigNumber, BigNumber, BigNumber],
+      [
+        string,
+        string,
+        string,
+        BigNumber,
+        BigNumber,
+        BigNumber,
+        BigNumber,
+        BigNumber
+      ],
       {
         liquidator: string;
         borrower: string;
         bond: string;
         underlyingAmount: BigNumber;
         seizedCollateralAmount: BigNumber;
+        repayCollateralAmount: BigNumber;
+        subsidizedCollateralAmount: BigNumber;
         profitCollateralAmount: BigNumber;
       }
     >;
@@ -265,15 +289,28 @@ export class ICollateralFlashUniswapV2 extends BaseContract {
       bond?: string | null,
       underlyingAmount?: null,
       seizedCollateralAmount?: null,
+      repayCollateralAmount?: null,
+      subsidizedCollateralAmount?: null,
       profitCollateralAmount?: null
     ): TypedEventFilter<
-      [string, string, string, BigNumber, BigNumber, BigNumber],
+      [
+        string,
+        string,
+        string,
+        BigNumber,
+        BigNumber,
+        BigNumber,
+        BigNumber,
+        BigNumber
+      ],
       {
         liquidator: string;
         borrower: string;
         bond: string;
         underlyingAmount: BigNumber;
         seizedCollateralAmount: BigNumber;
+        repayCollateralAmount: BigNumber;
+        subsidizedCollateralAmount: BigNumber;
         profitCollateralAmount: BigNumber;
       }
     >;

--- a/packages/tasks/src/deploy/collateralFlashUniswapV2.ts
+++ b/packages/tasks/src/deploy/collateralFlashUniswapV2.ts
@@ -7,10 +7,10 @@ import type { TaskArguments } from "hardhat/types";
 
 import {
   SUBTASK_DEPLOY_WAIT_FOR_CONFIRMATIONS,
-  TASK_DEPLOY_CONTRACT_HIFI_FLASH_UNISWAP_V2,
+  TASK_DEPLOY_CONTRACT_COLLATERAL_FLASH_UNISWAP_V2,
 } from "../../helpers/constants";
 
-task(TASK_DEPLOY_CONTRACT_HIFI_FLASH_UNISWAP_V2)
+task(TASK_DEPLOY_CONTRACT_COLLATERAL_FLASH_UNISWAP_V2)
   // Contract arguments
   .addParam("balanceSheet", "Address of the BalanceSheet contract")
   .addParam("uniV2Factory", "Address of the UniswapV2Factory contract")

--- a/packages/tasks/src/deploy/underlyingFlashUniswapV2.ts
+++ b/packages/tasks/src/deploy/underlyingFlashUniswapV2.ts
@@ -7,10 +7,10 @@ import type { TaskArguments } from "hardhat/types";
 
 import {
   SUBTASK_DEPLOY_WAIT_FOR_CONFIRMATIONS,
-  TASK_DEPLOY_CONTRACT_HIFI_FLASH_UNISWAP_V2_UNDERLYING,
+  TASK_DEPLOY_CONTRACT_UNDERLYING_FLASH_UNISWAP_V2,
 } from "../../helpers/constants";
 
-task(TASK_DEPLOY_CONTRACT_HIFI_FLASH_UNISWAP_V2_UNDERLYING)
+task(TASK_DEPLOY_CONTRACT_UNDERLYING_FLASH_UNISWAP_V2)
   // Contract arguments
   .addParam("balanceSheet", "Address of the BalanceSheet contract")
   .addParam("uniV2Factory", "Address of the UniswapV2Factory contract")


### PR DESCRIPTION
Deals with an edge case where the entire liquidated collateral is not enough to repay the Uniswap V2 0.3% swap fee. The subsidizer address should only be set when the client intends to prioritize liquidating all vaults regardless of profitability. When the collateral liquidation is to be subsidized, the minimum profit will not be taken into account.